### PR TITLE
Update jupytext_fileype_map RHS

### DIFF
--- a/plugin/jupytext.vim
+++ b/plugin/jupytext.vim
@@ -1,5 +1,5 @@
 " Name: jupytext.vim
-" Last Change: Jan 4, 2019
+" Last Change: Jul 9, 2019
 " Author:  Michael Goerz <https://michaelgoerz.net>
 " Plugin Website: https://github.com/goerz/jupytext.vim
 " Summary: Vim plugin for editing Jupyter ipynb files via jupytext
@@ -133,7 +133,7 @@ let s:jupytext_filetype_map = {
 \   'md': 'markdown',
 \   'Rmd': 'rmarkdown',
 \   'r': 'r',
-\   'py': 'py',
+\   'py': 'python',
 \   'jl': 'jl',
 \   'cpp': 'cpp',
 \   'ss': 'ss',

--- a/plugin/jupytext.vim
+++ b/plugin/jupytext.vim
@@ -134,7 +134,7 @@ let s:jupytext_filetype_map = {
 \   'Rmd': 'rmarkdown',
 \   'r': 'r',
 \   'py': 'python',
-\   'jl': 'jl',
+\   'jl': 'julia',
 \   'cpp': 'cpp',
 \   'ss': 'ss',
 \   'sh': 'sh',


### PR DESCRIPTION
This PR updates the `s:jupytext_fileype_map` to use default filetypes for `python` and `julia`. 
Also bumps version.

Let me know if you want to squash commits, make changes, use different version etc.