### PR TITLE
use utf-8 on reading/writing

### DIFF
--- a/plugin/jupytext.vim
+++ b/plugin/jupytext.vim
@@ -277,7 +277,7 @@ function s:read_from_ipynb()
         " jupytext_file does not exist if filename_exists was false, e.g. when
         " we edit a new file (vim new.ipynb)
         call s:debugmsg("read ".fnameescape(b:jupytext_file))
-        silent execute "read ".fnameescape(b:jupytext_file)
+        silent execute "read ++enc=utf-8 ".fnameescape(b:jupytext_file)
     endif
     if b:jupytext_file_exists
         let l:register_unload_cmd = "autocmd BufUnload <buffer> call s:cleanup(\"".fnameescape(b:jupytext_file)."\", 0)"
@@ -290,7 +290,7 @@ function s:read_from_ipynb()
     let l:ft = get(g:jupytext_filetype_map, g:jupytext_fmt,
     \              s:jupytext_filetype_map[g:jupytext_fmt])
     call s:debugmsg("filetype: ".l:ft)
-    silent execute "set ft=".l:ft
+    silent execute "setl fenc=utf-8 ft=".l:ft
     " In order to make :undo a no-op immediately after the buffer is read,
     " we need to do this dance with 'undolevels'.  Actually discarding the
     " undo history requires performing a change after setting 'undolevels'


### PR DESCRIPTION
For the markdown format, jupytext assumes that the given file is encoded in utf-8 https://github.com/mwouts/jupytext/commit/565f28c460e395980c612dec233c601f37e37600.

However, currently, the value of `fileencoding` of the file obtained from jupytext is set to the default value of vim.
This depends on the user settings of `encoding` and `fileencoding` of vim.
In addition, unfortunately, the default encoding of Vim is not UTF-8 on Windows.

When the default fileencoding of vim is not utf-8, I recieved the following error from jupytext:
> UnicodeDecodeError: 'utf-8' codec can't decode byte 0x81 in position 5991: invalid start byte

This PR fixes this.
However I don't know well about encodings of the formats other than markdown format.