### PR TITLE
add a version guard for patched :au ++once

### DIFF
--- a/plugin/jupytext.vim
+++ b/plugin/jupytext.vim
@@ -305,7 +305,12 @@ function s:read_from_ipynb()
     set undolevels=-1
     silent 1delete
     let &undolevels = levels
-    silent execute "autocmd jupytext_ipynb BufEnter <buffer> ++once redraw | echo fnamemodify(b:jupytext_file, ':.').' via jupytext.'"
+    if has("patch-8.1.1113")
+        silent execute "autocmd jupytext_ipynb BufEnter <buffer> ++once redraw | echo fnamemodify(b:jupytext_file, ':.').' via jupytext.'"
+    else
+        silent execute "autocmd jupytext_ipynb BufEnter <buffer> redraw | echo fnamemodify(b:jupytext_file, ':.').' via jupytext.'"
+    endif
+
 endfunction
 
 


### PR DESCRIPTION
The `:autocmd` `++once` argument was introduced [in Vim patch 8.1.1113](https://github.com/vim/vim/blame/master/runtime/doc/autocmd.txt#L54), so it will break for Vim users without the patch.  I added a quick patch check to ensure we can use `++once`.