### PR TITLE
Write asynchronously on neovim

### DIFF
--- a/plugin/jupytext.vim
+++ b/plugin/jupytext.vim
@@ -339,7 +339,7 @@ function s:write_to_ipynb() abort
     \         . " " . g:jupytext_to_ipynb_opts . " "
     \         . shellescape(b:jupytext_file)
     call s:debugmsg("cmd: ".l:cmd)
-    if has("job") || has("nvim")
+    if has("nvim")
         call s:async_system(l:cmd, "s:jupytext_exit_callback")
     else
         let l:output=system(l:cmd)
@@ -354,18 +354,7 @@ function s:write_to_ipynb() abort
 endfunction
 
 function! s:async_system(cmd, callback)
-    echom a:cmd
-    if has("nvim")
-        call jobstart(a:cmd, {"on_exit": function(a:callback)})
-    else
-        call job_start(a:cmd, {"exit_cb": function(a:callback . "_vim"), "err_io": "out", "out_io": "file", "out_name": "/tmp/jupytext_vim_job_out.txt"})
-    endif
-endfunction
-
-function s:jupytext_exit_callback_vim(job, exit_status)
-    echom a:exit_status
-    echom a:job
-    call s:jupytext_exit_callback(a:job, a:exit_status, 0)
+    call jobstart(a:cmd, {"on_exit": function(a:callback)})
 endfunction
 
 function s:jupytext_exit_callback(id, data, event) abort

--- a/plugin/jupytext.vim
+++ b/plugin/jupytext.vim
@@ -354,7 +354,18 @@ function s:write_to_ipynb() abort
 endfunction
 
 function! s:async_system(cmd, callback)
-    call jobstart(a:cmd, {'on_exit': function(a:callback)})
+    echom a:cmd
+    if has("nvim")
+        call jobstart(a:cmd, {"on_exit": function(a:callback)})
+    else
+        call job_start(a:cmd, {"exit_cb": function(a:callback . "_vim"), "err_io": "out", "out_io": "file", "out_name": "/tmp/jupytext_vim_job_out.txt"})
+    endif
+endfunction
+
+function s:jupytext_exit_callback_vim(job, exit_status)
+    echom a:exit_status
+    echom a:job
+    call s:jupytext_exit_callback(a:job, a:exit_status, 0)
 endfunction
 
 function s:jupytext_exit_callback(id, data, event) abort

--- a/plugin/jupytext.vim
+++ b/plugin/jupytext.vim
@@ -361,11 +361,11 @@ function s:jupytext_exit_callback(id, data, event) abort
     if a:data == 0
         setlocal nomodified
         echohl ModeMsg
-        echomsg "jupytext.vim: notebook updated"
+        echomsg "jupytext.vim: updated notebook " . expand("%")
         echohl Normal
     else
         echohl ErrorMsg
-        echomsg "jupytext.vim: notebook update failed!"
+        echomsg "jupytext.vim: update failed for notbook " . expand("%")
         echohl Normal
     endif
 endfunction


### PR DESCRIPTION
Prevents editor blocking for a few seconds every write

Uses old functionality if the editor version doesn't support jobstart (I.e. isn't neovim). I tried to get it working for vim, but the callback api was too complicated for me.

The only regression this adds is that the specific error code won't be shown if jupytext encounters a problem. But the error code seems rarely useful anyway compared to the output from actually running it in terminal.

This PR is based off my previous one #16, and includes commits from that. If you want to merge both PRs, merge only this one.