### PR TITLE
Added support to specify output format for plain text conversion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The plugin has the following settings. If you want to override the default value
 
     The format to which to convert the `ipynb` data. This can be any format that the `jupytext` utility accepts for its `--to` parameter (see `jupytext --help`), except for `'notebook'` and `'ipynb'`.
 
+*   `let g:jupytext_style = ''`
+
+    The jupytext output format generated when converting a notebook to plain text. Check `jupytext --help` to see the available output formats.
+
 *  `let g:jupytext_to_ipynb_opts = '--to=ipynb --update'`
 
    Command line options for the conversion from `g:jupytext_fmt` back to the notebook format

--- a/plugin/jupytext.vim
+++ b/plugin/jupytext.vim
@@ -230,6 +230,14 @@ if !exists('g:jupytext_fmt')
     let g:jupytext_fmt = 'md'
 endif
 
+if !exists('g:jupytext_style')
+    let g:jupytext_style = ''
+else
+    " Add semicolon so that everything works when
+    " interpolating into the jupytext command.
+    let g:jupytext_style = ':'.g:jupytext_style
+endif
+
 if !exists('g:jupytext_to_ipynb_opts')
     let g:jupytext_to_ipynb_opts = '--to=ipynb --update'
 endif
@@ -263,7 +271,7 @@ function s:read_from_ipynb()
     call s:debugmsg("jupytext_file exists: ".b:jupytext_file_exists)
     if (l:filename_exists && !b:jupytext_file_exists)
         call s:debugmsg("Generate file ".b:jupytext_file)
-        let l:cmd = g:jupytext_command." --to=".g:jupytext_fmt
+        let l:cmd = g:jupytext_command." --to=".g:jupytext_fmt.g:jupytext_style
         \         . " --output=".shellescape(b:jupytext_file) . " "
         \         . shellescape(l:filename)
         call s:debugmsg("cmd: ".l:cmd)


### PR DESCRIPTION
A new variable `g:jupytext_style` can be used to specify the format for the notebook to plain text conversion. For example:
```
let g:jupytext_style='hydrogen'
```
to always use the hydrogen format when generating scripts.


If left unspecified it is up to jupytext to decide on the default, in line with the current behaviour.

This is for the benefit of users of other plugins and tools that depend on a specific output format other than the default.