### PR TITLE
Fix error that prevents deletion of Jupytext file

### DIFF
--- a/plugin/jupytext.vim
+++ b/plugin/jupytext.vim
@@ -352,7 +352,7 @@ function s:cleanup(jupytext_file, delete)
     call s:debugmsg("a:jupytext_file:".a:jupytext_file)
     if a:delete
         call s:debugmsg("deleting ".fnameescape(a:jupytext_file))
-        call delete(expand(fnameescape(a:jupytext_file)))
+        call delete(fnameescape(a:jupytext_file))
     endif
 endfunction
 


### PR DESCRIPTION
I noticed that the generated jupytext file was not successfully deleted when closing the buffer.
The debug messages showed that `s:cleanup` was invoked, but something complained about a wrong argument.
Then I noticed a discrepancy in `s:cleanup` between the message and the actual delete command:

Message: `fnameescape(a:jupytext_file)`

Delete command: `expand(fnameescape(a:jupytext_file))`

I'm not sure what the `expand()` is for. But when I deleted it, the delete command was successful.